### PR TITLE
fix: https://github.com/mob-sakai/ParticleEffectForUGUI/issues/119

### DIFF
--- a/Scripts/Utils.cs
+++ b/Scripts/Utils.cs
@@ -9,8 +9,9 @@ namespace Coffee.UIParticleExtensions
     internal static class SpriteExtensions
     {
 #if UNITY_EDITOR
-        private static Type tSpriteEditorExtension = Type.GetType("UnityEditor.Experimental.U2D.SpriteEditorExtension, UnityEditor")
-                                                     ?? Type.GetType("UnityEditor.U2D.SpriteEditorExtension, UnityEditor");
+        private static Type tSpriteEditorExtension =
+            Type.GetType("UnityEditor.Experimental.U2D.SpriteEditorExtension, UnityEditor")
+            ?? Type.GetType("UnityEditor.U2D.SpriteEditorExtension, UnityEditor");
 
         private static MethodInfo miGetActiveAtlasTexture = tSpriteEditorExtension
             .GetMethod("GetActiveAtlasTexture", BindingFlags.Static | BindingFlags.NonPublic);
@@ -222,28 +223,40 @@ namespace Coffee.UIParticleExtensions
                 if (!Mathf.Approximately(aPos, bPos))
                     return (int) Mathf.Sign(bPos - aPos);
 
+                return (int) Mathf.Sign(GetIndex(self, a) - GetIndex(self, b));
+
                 // Material instance ID: match
-                if (aMat.GetInstanceID() == bMat.GetInstanceID())
-                    return 0;
+                // if (aMat.GetInstanceID() == bMat.GetInstanceID())
+                // return 0;
 
                 // Transform: ascending
-                return TransformCompare(aTransform, bTransform);
+                // return TransformCompare(aTransform, bTransform);
             });
         }
 
-        private static int TransformCompare(Transform a, Transform b)
+        private static int GetIndex(IReadOnlyList<ParticleSystem> list, Object ps)
         {
-            while (true)
+            for (var i = 0; i < list.Count; i++)
             {
-                if (!a && !b) return 0;
-                if (!a) return -1;
-                if (!b) return 1;
-                if (a.parent == b.parent) return a.GetSiblingIndex() - b.GetSiblingIndex();
-
-                a = a.parent;
-                b = b.parent;
+                if (list[i].GetInstanceID() == ps.GetInstanceID()) return i;
             }
+
+            return 0;
         }
+
+        // private static int TransformCompare(Transform a, Transform b)
+        // {
+        //     while (true)
+        //     {
+        //         if (!a && !b) return 0;
+        //         if (!a) return -1;
+        //         if (!b) return 1;
+        //         if (a.parent == b.parent) return a.GetSiblingIndex() - b.GetSiblingIndex();
+        //
+        //         a = a.parent;
+        //         b = b.parent;
+        //     }
+        // }
 
         public static long GetMaterialHash(this ParticleSystem self, bool trail)
         {


### PR DESCRIPTION
[ignore material check and transform check]
[add default sort by index]
Material check maybe not necessary and GetComponentsInChildren has correct sort.