### PR TITLE
fix: Multiselecting sets all scales to the same value

### DIFF
--- a/Scripts/Editor/UIParticleEditor.cs
+++ b/Scripts/Editor/UIParticleEditor.cs
@@ -260,9 +260,9 @@ namespace Coffee.UIExtensions
                     z.floatValue = y.floatValue = x.floatValue;
             }
 
-            x.floatValue = Mathf.Max(0.001f, x.floatValue);
-            y.floatValue = Mathf.Max(0.001f, y.floatValue);
-            z.floatValue = Mathf.Max(0.001f, z.floatValue);
+            if (x.floatValue < 0.001f) x.floatValue = 0.001f;
+            if (y.floatValue < 0.001f) y.floatValue = 0.001f;
+            if (z.floatValue < 0.001f) z.floatValue = 0.001f;
 
             EditorGUI.BeginChangeCheck();
             showXyz = GUILayout.Toggle(showXyz, s_Content3D, EditorStyles.miniButton, GUILayout.Width(30));

--- a/Scripts/Editor/UIParticleEditor.cs
+++ b/Scripts/Editor/UIParticleEditor.cs
@@ -250,19 +250,26 @@ namespace Coffee.UIExtensions
             EditorGUILayout.BeginHorizontal();
             if (showXyz)
             {
+                EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(sp);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    x.floatValue = Mathf.Max(0.001f, x.floatValue);
+                    y.floatValue = Mathf.Max(0.001f, y.floatValue);
+                    z.floatValue = Mathf.Max(0.001f, z.floatValue);
+                }
             }
             else
             {
                 EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(x, s_ContentScale);
                 if (EditorGUI.EndChangeCheck())
-                    z.floatValue = y.floatValue = x.floatValue;
+                {
+                    x.floatValue = Mathf.Max(0.001f, x.floatValue);
+                    y.floatValue = Mathf.Max(0.001f, x.floatValue);
+                    z.floatValue = Mathf.Max(0.001f, x.floatValue);
+                }
             }
-
-            if (x.floatValue < 0.001f) x.floatValue = 0.001f;
-            if (y.floatValue < 0.001f) y.floatValue = 0.001f;
-            if (z.floatValue < 0.001f) z.floatValue = 0.001f;
 
             EditorGUI.BeginChangeCheck();
             showXyz = GUILayout.Toggle(showXyz, s_Content3D, EditorStyles.miniButton, GUILayout.Width(30));


### PR DESCRIPTION
Hello! I found a little bug
How to reproduce: Select two GameObjects with UiParticle component and different scale values. (Unity version 2019.3.3f1)
What will happen: scale of both UiParticles will be set to same value
What should happened: scale of UiParticles should stay the same

My fix should help. 