### PR TITLE
Prevent warning CS0618: 'PrefabStage.prefabAssetPath' is obsolete: 'prefabAssetPath has been deprecated. Use assetPath instead.'

### DIFF
--- a/Scripts/Editor/UIParticleEditor.cs
+++ b/Scripts/Editor/UIParticleEditor.cs
@@ -216,7 +216,12 @@ namespace Coffee.UIExtensions
             var stage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
             if (stage != null && stage.scene.isLoaded)
             {
-                PrefabUtility.SaveAsPrefabAsset(stage.prefabContentsRoot, stage.prefabAssetPath);
+#if UNITY_2020_1_OR_NEWER
+				string prefabAssetPath = stage.assetPath;
+#else
+				string prefabAssetPath = stage.prefabAssetPath;
+#endif
+				PrefabUtility.SaveAsPrefabAsset(stage.prefabContentsRoot, prefabAssetPath);
             }
 #endif
         }

--- a/Scripts/Editor/UIParticleEditor.cs
+++ b/Scripts/Editor/UIParticleEditor.cs
@@ -217,11 +217,11 @@ namespace Coffee.UIExtensions
             if (stage != null && stage.scene.isLoaded)
             {
 #if UNITY_2020_1_OR_NEWER
-				string prefabAssetPath = stage.assetPath;
+                string prefabAssetPath = stage.assetPath;
 #else
-				string prefabAssetPath = stage.prefabAssetPath;
+                string prefabAssetPath = stage.prefabAssetPath;
 #endif
-				PrefabUtility.SaveAsPrefabAsset(stage.prefabContentsRoot, prefabAssetPath);
+                PrefabUtility.SaveAsPrefabAsset(stage.prefabContentsRoot, prefabAssetPath);
             }
 #endif
         }


### PR DESCRIPTION
お疲れ様です。

非常に役に立つパッケージです、感謝致します！

一件だけですが、こちらで使われているUnity 2020.3.11f1だと以下の警告が発生されます：ー
warning CS0618: 'PrefabStage.prefabAssetPath' is obsolete: 'prefabAssetPath has been deprecated. Use assetPath instead.'

どのバージョンからこのプロパティがdeprecatedになっていたのがわかりませんが、少なくとも2020.1のようです：ー
https://githubmemory.com/repo/yasirkula/UnityAssetUsageDetector/issues/24

こちらのよう変更で警告を回避させていただけますでしょうか。

よろしくお願い致します。

Thank-you for providing this very useful package.

We encountered one minor issue under Unity 2020.3.11f1, in which the following warning is generated:-
warning CS0618: 'PrefabStage.prefabAssetPath' is obsolete: 'prefabAssetPath has been deprecated. Use assetPath instead.'

We are not sure in which version this property became deprecated, but at the least it seems to have occurred by 2020.1:-
https://githubmemory.com/repo/yasirkula/UnityAssetUsageDetector/issues/24

Might a change like this be accepted in order to avoid the warning?

Thank-you for your consideration.