### PR TITLE
Fix PrefabStageUtility not experimental after 2021.2

### DIFF
--- a/Scripts/BakingCamera.cs
+++ b/Scripts/BakingCamera.cs
@@ -17,7 +17,11 @@ namespace Coffee.UIParticleExtensions
             get
             {
                 // If current scene is prefab mode, create OverlayCamera for editor.
+#if UNITY_2021_2_OR_NEWER
+                var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#else
                 var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#endif
                 if (prefabStage == null || !prefabStage.scene.isLoaded) return null;
                 if (s_InstanceForPrefab) return s_InstanceForPrefab;
 

--- a/Scripts/Editor/UIParticleEditor.cs
+++ b/Scripts/Editor/UIParticleEditor.cs
@@ -212,8 +212,12 @@ namespace Coffee.UIExtensions
             DestroyImmediate(p);
             DestroyImmediate(cr);
 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
+            var stage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#elif UNITY_2018_3_OR_NEWER
             var stage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#endif
+#if UNITY_2018_3_OR_NEWER
             if (stage != null && stage.scene.isLoaded)
             {
 #if UNITY_2020_1_OR_NEWER


### PR DESCRIPTION
After Unity **2021.2,** `PrefabStageUtility` is not at `Experimental` namespace anymore.

Sometimes you don't see this as a problem because Unity process your package and updates the code automatically when opening the Editor. But it causes you problems when using the command line to build and code is not updated.

This PR aims to fix this problem.