### PR TITLE
Fixed the annoying empty black scene overlay box shown even when noth…

### DIFF
--- a/Scripts/Editor/UIParticleEditor.cs
+++ b/Scripts/Editor/UIParticleEditor.cs
@@ -102,7 +102,7 @@ namespace Coffee.UIExtensions
 #endif
 
 #if UNITY_2019_1_OR_NEWER
-            SceneView.duringSceneGui += _ => miSceneViewOverlayWindow.Invoke(null, sceneViewArgs);
+            SceneView.duringSceneGui += _ => { if (s_SerializedObject != null) miSceneViewOverlayWindow.Invoke(null, sceneViewArgs); };
 #else
             SceneView.onSceneGUIDelegate += _ =>
 #endif


### PR DESCRIPTION
…ing is selected.
![image](https://user-images.githubusercontent.com/33001312/187279139-dbff19e1-79a2-4167-a10e-5c2280296587.png)
The overlay box in bottom right corner of the scene view didn't go away when I deselected the particle GameObject. I'm using Unity 2020.2.7f1.