### PR TITLE
fix: remove per-frame allocation in UIParticle

### DIFF
--- a/Scripts/UIParticle.cs
+++ b/Scripts/UIParticle.cs
@@ -323,9 +323,13 @@ namespace Coffee.UIExtensions
         {
             if (!isActiveAndEnabled) return;
 
-            if (m_Renderers.Any(x => !x))
+            foreach (var rend in m_Renderers)
             {
-                RefreshParticles(particles);
+                if (!rend)
+                {
+                    RefreshParticles(particles);
+                    break;
+                }
             }
 
             var bakeCamera = GetBakeCamera();


### PR DESCRIPTION
UIParticle.UpdateRenderers() produces a sizable per-frame allocation due to the use of LINQ's Any() method. Replacing said method usage with a simple foreach loop entirely removes the allocation and reduces overall GC pressure.