### PR TITLE
Update UIParticle.cs to change default scale to Vector3.one

### DIFF
--- a/Runtime/UIParticle.cs
+++ b/Runtime/UIParticle.cs
@@ -58,7 +58,7 @@ namespace Coffee.UIExtensions
 
         [Tooltip("Particle effect scale")]
         [SerializeField]
-        private Vector3 m_Scale3D = new Vector3(10, 10, 10);
+        private Vector3 m_Scale3D = new Vector3(1, 1, 1);
 
         [Tooltip("Animatable material properties.\n" +
                  "If you want to change the material properties of the ParticleSystem in Animation, enable it.")]


### PR DESCRIPTION
We've had some missteps with the default scaling of the particle system. Our VFX designer designs the particles but doesn't realize the default scale on the script is 10, and so has to go and do a lot of work editing the coefficients in the system (multiplying them all by 10) to get the VFX prefab to be correctly scaled.

Propose: The default value for scaling is Vector3.one instead of 10f.

---
name: Pull Request
about: Create a pull request
title: ''
assignees: mob-sakai

---

**NOTE: Create a pull request to merge into `develop` branch**
