### PR TITLE
UIParticle in Canvas with Zero Alpha not Playing Fix

### DIFF
--- a/Packages/src/Runtime/UIParticleRenderer.cs
+++ b/Packages/src/Runtime/UIParticleRenderer.cs
@@ -283,10 +283,6 @@ namespace Coffee.UIExtensions
                 || !transform.lossyScale.GetScaled(_parent.scale3DForCalc).IsVisible() // Scale is not visible.
                 || (!_particleSystem.IsAlive() && !_particleSystem.isPlaying) // No particle.
                 || (_isTrail && !_particleSystem.trails.enabled) // Trail, but it is not enabled.
-#if UNITY_2018_3_OR_NEWER
-                || canvasRenderer.GetInheritedAlpha() <
-                0.01f // #102: Do not bake particle system to mesh when the alpha is zero.
-#endif
             )
             {
                 Profiler.BeginSample("[UIParticleRenderer] Clear Mesh");


### PR DESCRIPTION
Fixed a bug where UIParticle in canvas with 0f-0.01f alpha value does not start to play until alpha value is greater than 0.01f, causes play calls to be delayed unintentionally if canvas alpha value is set to mentioned value range.