### PR TITLE
Add meshCleared flag to optimize mesh clearing

### DIFF
--- a/Packages/src/Runtime/UIParticleRenderer.cs
+++ b/Packages/src/Runtime/UIParticleRenderer.cs
@@ -30,6 +30,7 @@ namespace Coffee.UIExtensions
         private int _index;
         private bool _isPrevStored;
         private bool _isTrail;
+        private bool _meshCleared;
         private Bounds _lastBounds;
         private Material _materialForRendering;
         private Material _modifiedMaterial;
@@ -285,10 +286,14 @@ namespace Coffee.UIExtensions
                 || (_isTrail && !_particleSystem.trails.enabled) // Trail, but it is not enabled.
             )
             {
+                // Skip clearing the mesh if it's already cleared.
+                if (_meshCleared) return;
+
                 Profiler.BeginSample("[UIParticleRenderer] Clear Mesh");
                 workerMesh.Clear();
                 canvasRenderer.SetMesh(workerMesh);
                 _lastBounds = new Bounds();
+                _meshCleared = true;
                 Profiler.EndSample();
 
                 return;
@@ -312,6 +317,7 @@ namespace Coffee.UIExtensions
             //     customData.SetVector(ParticleSystemCustomData.Custom2, 3, 0);
             // }
 
+            _meshCleared = false;
             var main = _particleSystem.main;
             var scale = GetWorldScale();
             var psPos = _particleSystem.transform.position;


### PR DESCRIPTION
### Summary

I found that `mesh.Clear()` was being called every frame even when `UIParticleRenderer` was disabled.

<img width="1268" height="79" alt="image" src="https://github.com/user-attachments/assets/1504032d-2a78-42fa-bfe0-fbab4f634f8c" />

PR Prevents  every frame calls of redundant `workerMesh.Clear()` in `UIParticleRenderer` by skipping the clear path when the mesh has already been cleared.

